### PR TITLE
Add option to set base for hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ sortable.decode(biggerHash, 3);
 Hash the array `values`, which may only contain Numbers in the range of
 `[-100, 100]`.
 
-`options` can either be an object with those possible keys:
+`options` can either be an object with these possible keys:
 
 * `precision`: Length of the resulting hash
+* `base`: Number base for hash (i.e. limits the bits per character). One of 2,4,8,16, or 32 (default)
 
 or a Number, in which case it sets `options.precision`.
 
@@ -54,10 +55,16 @@ or a Number, in which case it sets `options.precision`.
 encode([10], 13) === encode([10], { precision: 13 });
 ```
 
-### sortable.decode(string, numValues)
+### sortable.decode(string, options)
 
-Decode `string` into an Array of Numbers. `numValues` needs to be the number
-of elements initially passed to `hash.encode`.
+Decode `string` into an Array of Numbers.
+
+`options` can either be an object with these possible keys:
+
+* `num`: number of elements initially passed to `hash.encode`. (required)
+* `base`: Number base for hash (i.e. limits the bits per character). One of 2,4,8,16, or 32 (default)
+
+Or a Number, in which case it sets `options.num` 
 
 ## Installation
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -18,6 +18,22 @@ test('integration', function (t) {
   t.deepEqual(i(decode(encode([10, -10, 10], 6), 3)), [10, -10, 10]);
 });
 
+test('integration base16', function (t) {
+  t.plan(9);
+
+  t.deepEqual(i(decode(encode([10], {base: 16}), {num: 1, base: 16})), [10]);
+  t.deepEqual(i(decode(encode([10], {precision: 24, base: 16}), {num: 1, base: 16})), [10]);
+  t.deepEqual(i(decode(encode([10], {precision: 6, base: 16}), {num: 1, base: 16})), [10]);
+
+  t.deepEqual(i(decode(encode([10, -10], {base: 16}), {num: 2, base: 16})), [10, -10]);
+  t.deepEqual(i(decode(encode([10, -10], {precision: 24, base: 16}), {num: 2, base: 16})), [10, -10]);
+  t.deepEqual(i(decode(encode([10, -10], {precision: 6, base: 16}), {num: 2, base: 16})), [10, -10]);
+
+  t.deepEqual(i(decode(encode([10, -10, 10], {base: 16}), {num: 3, base: 16})), [10, -10, 10]);
+  t.deepEqual(i(decode(encode([10, -10, 10], {precision: 24, base: 16}), {num: 3, base: 16})), [10, -10, 10]);
+  t.deepEqual(i(decode(encode([10, -10, 10], {precision: 6, base: 16}), {num: 3, base: 16})), [10, -10, 10]);
+});
+
 function i (arr) {
   return arr.map(function (e) {
     return Math.round(e);


### PR DESCRIPTION
This adds an option to specify a base (2, 4, 8, 16, or 32 (default)) for both encoding and decoding.  Also includes "intergration" tests for base 16, and update to readme.

These are non-breaking changes, everything is backwards compatible and defaults to the same values as before.

E.G.
var hash = sortable.encode([10, 11], {precision: 12, base: 16}
var data = sortable.decode(hash, {num: 2, base: 16}
